### PR TITLE
generated code for the Dexterity content class was missing a 'pass'

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,10 +1,14 @@
 Changelog
 =========
 
-1.5.4 (unreleased)
+1.5.4 (2013-12-11)
 ------------------
 
 - fixed improper code template for Python content class
+- base class of generated content class code was always
+  Container (without taking the 'folderish' value of the
+  configuration into account).
+  [ajung]
 
 
 1.5.3 (2013-07-28)

--- a/zopeskel/dexterity/localcommands/templates/dexterity/content/+content_class_filename+.py_tmpl
+++ b/zopeskel/dexterity/localcommands/templates/dexterity/content/+content_class_filename+.py_tmpl
@@ -8,7 +8,13 @@ from zope.interface import invariant, Invalid
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 
+#if str($folderish) == 'True'
 from plone.dexterity.content import Container
+#else
+from plone.dexterity.content import Item
+#end if
+
+#
 #if str($grokish) == 'True'
 from plone.directives import dexterity, form
 #end if
@@ -59,7 +65,12 @@ class ${interface_name}(model.Schema, IImageScaleTraversable):
 \# methods and properties. Put methods that are mainly useful for rendering
 \# in separate view classes.
 
+#if str($folderish) == 'True'
 class ${contenttype_classname}(Container):
+#else
+class ${contenttype_classname}(Item):
+#end
+#
 #if str($grokish) == 'True'
     grok.implements(${interface_name})
 #end if


### PR DESCRIPTION
statement - otherwise syntactically incorrect code was produced
