### PR TITLE
added an extras_require['test'] entry to the setup.py_tmpl file

### DIFF
--- a/zopeskel/dexterity/templates/dexterity/setup.py_tmpl
+++ b/zopeskel/dexterity/templates/dexterity/setup.py_tmpl
@@ -55,5 +55,12 @@ setup(name=${repr($project)},
       # your package.
       setup_requires=["PasteScript"],
       paster_plugins = ["ZopeSkel"],
+      extras_require = {
+      'test': [
+            'plone.app.testing',
+            'plone.app.robotframework',
+            'Products.PloneTestCase',
+        ],
+      },
 
       )


### PR DESCRIPTION
Having an extras_require['test'] section in the setup.py supports the methodology of providing tests in an "extra" which can then be registered in buildout as follows:

```
  my.package[test]
```

this reduces the number of steps required when getting started with an add-on package and makes it easier to get started quickly with testing.
