### PR TITLE
ZopeSkel 3 is no-go

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Add these lines into buildout::
   [zopeskel]
   recipe = zc.recipe.egg
   eggs =
-     ZopeSkel <= 3.0
+     ZopeSkel < 3.0dev
      Paste
      PasteDeploy
      PasteScript


### PR DESCRIPTION
zopeskel.dexterity was written for zopeskel 2 and does not work reliably with zopeskel 3+